### PR TITLE
Replacing some hard-coded parameters with "fabm" parameter instances

### DIFF
--- a/src/phytoplankton.F90
+++ b/src/phytoplankton.F90
@@ -92,7 +92,6 @@ contains
       call self%get_parameter(self%diatom, 'diatom', '', 'use silicate', default=.false.)
       call self%get_parameter(self%calcify, 'calcify', '', 'calcify', default=.false.)
       call self%get_parameter(self%mumax0, 'mumax0', 'd-1', 'maximum growth rate at 0 degrees Celsius', default=0.8_rk)    ! default=0.8 in NEMO-PISCES 4 code, confirmed by Olivier Aumont 2021-04-21
-      call self%get_parameter(self%logbp, 'logbp', '-', '(log of) Temperature sensitivity of growth', default=0.063913_rk) ! AC -07.12.2021 - Aumont et al. 2015, Table 1, Eq. 4a, Using log(b_p) instead of b_p.
       call self%get_parameter(self%bp, 'bp', '-', 'Temperature sensitivity of growth',default=1.066_rk)
       call self%get_parameter(self%logbp, 'logbp', '-', 'Temperature sensitivity of growth (log rate, overwrites bp if given explicitely)', default= log(self%bp))
       call self%get_parameter(self%fpday, 'fpday', '-', 'day-length factor for growth', default=1.5_rk) ! AC -07.12.2021 - Aumont et al. 2015, Eq 3a

--- a/src/phytoplankton.F90
+++ b/src/phytoplankton.F90
@@ -28,6 +28,8 @@ module pisces_phytoplankton
       logical :: diatom
       logical :: calcify
       real(rk) :: mumax0
+      real(rk) :: logbp
+      real(rk) :: fpday
       real(rk) :: bresp
       real(rk) :: pislope_s
       real(rk) :: pislope_l
@@ -89,9 +91,11 @@ contains
       call self%get_parameter(self%diatom, 'diatom', '', 'use silicate', default=.false.)
       call self%get_parameter(self%calcify, 'calcify', '', 'calcify', default=.false.)
       call self%get_parameter(self%mumax0, 'mumax0', 'd-1', 'maximum growth rate at 0 degrees Celsius', default=0.8_rk)    ! default=0.8 in NEMO-PISCES 4 code, confirmed by Olivier Aumont 2021-04-21
+      call self%get_parameter(self%logbp, 'logbp', '-', '(log of) Temperature sensitivity of growth', default=0.063913_rk) ! AC -07.12.2021 - Aumont et al. 2015, Table 1, Eq. 4a, Using log(b_p) instead of b_p. 
+      call self%get_parameter(self%fpday, 'fpday', '-', 'day-length factor for growth', default=1.5_rk) ! AC -07.12.2021 - Aumont et al. 2015, Eq 3a
       call self%get_parameter(self%bresp, 'bresp', 'd-1', 'basal respiration', default=0.033_rk)
       call self%get_parameter(self%pislope_s, 'pislope_s', 'g C (g Chl)-1 (W m-2)-1 d-1', 'P-I slope for small cells', default=2._rk)
-      call self%get_parameter(self%pislope_l, 'pislope_l', 'g C (g Chl)-1 (W m-2)-1 d-1', 'P-I slope for large cells', default=2._rk)
+      call self%get_parameter(self%pislope_l, 'pislope_l', 'g C (g Chl)-1 (W m-2)-1 d-1', 'P-I slope for large cells', default=self%pislope_s) ! AC -07.12.2021 - changed default value to pislope_s to ensure common perturbation.
       call self%get_parameter(self%xadap, 'xadap', '-', 'acclimation factor to low light', default=0._rk)
       call self%get_parameter(self%excret, 'excret', '1', 'fraction of production that is excreted', default=0.05_rk)
       call self%get_parameter(par_model%beta1, 'beta1', '1', 'absorption in blue part of the light')
@@ -316,7 +320,8 @@ contains
 
          ! ======================================================================================
          ! Jorn: From p4zint
-         tgfunc = EXP( 0.063913 * tem )  ! Jorn: Eq 4a in PISCES-v2 paper, NB EXP(0.063913) = 1.066 = b_P
+         !tgfunc = EXP( 0.063913 * tem )  ! Jorn: Eq 4a in PISCES-v2 paper, NB EXP(0.063913) = 1.066 = b_P
+         tgfunc = EXP( self%logbp * tem )  ! AC 07.12.2021 - replaced hard-coded value with parameter for bp. Log(bp) considered instead of bp for perturbation purposes).
          ! ======================================================================================
 
          ! ======================================================================================
@@ -370,7 +375,8 @@ contains
                zval = zval * MIN(1._rk, heup_01 / ( hmld + rtrn ))   ! Jorn: when in mixing layer, multiply with fraction of time spent in euphotic depth; it seems to be an easier-to-understand substitute for Eq 3b-3d
             ENDIF
             zmxl_chl = zval / 24._rk  ! Jorn: from number of hours to fraction of day
-            zmxl_fac = 1.5_rk * zval / ( 12._rk + zval )  ! Jorn: Eq 3a in PISCES-v2 paper - but note that time spent in euphotic layer has already been incorporated in zval! Eqs 3b-3d are not used
+            !zmxl_fac = 1.5_rk * zval / ( 12._rk + zval )  ! Jorn: Eq 3a in PISCES-v2 paper - but note that time spent in euphotic layer has already been incorporated in zval! Eqs 3b-3d are not used
+            zmxl_fac = self%fpday * zval / ( 12._rk + zval )  ! AC 07.12.2021 - fpday as parameter 
 
             zpr = zprmax * zmxl_fac  ! Jorn: product of muP and f1*f2 (sort of - those have been changed) in Eq 2a, units are 1/s
 

--- a/src/phytoplankton.F90
+++ b/src/phytoplankton.F90
@@ -28,6 +28,7 @@ module pisces_phytoplankton
       logical :: diatom
       logical :: calcify
       real(rk) :: mumax0
+      real(rk) :: bp
       real(rk) :: logbp
       real(rk) :: fpday
       real(rk) :: bresp
@@ -91,7 +92,9 @@ contains
       call self%get_parameter(self%diatom, 'diatom', '', 'use silicate', default=.false.)
       call self%get_parameter(self%calcify, 'calcify', '', 'calcify', default=.false.)
       call self%get_parameter(self%mumax0, 'mumax0', 'd-1', 'maximum growth rate at 0 degrees Celsius', default=0.8_rk)    ! default=0.8 in NEMO-PISCES 4 code, confirmed by Olivier Aumont 2021-04-21
-      call self%get_parameter(self%logbp, 'logbp', '-', '(log of) Temperature sensitivity of growth', default=0.063913_rk) ! AC -07.12.2021 - Aumont et al. 2015, Table 1, Eq. 4a, Using log(b_p) instead of b_p. 
+      call self%get_parameter(self%logbp, 'logbp', '-', '(log of) Temperature sensitivity of growth', default=0.063913_rk) ! AC -07.12.2021 - Aumont et al. 2015, Table 1, Eq. 4a, Using log(b_p) instead of b_p.
+      call self%get_parameter(self%bp, 'bp', '-', 'Temperature sensitivity of growth',default=1.066_rk)
+      call self%get_parameter(self%logbp, 'logbp', '-', 'Temperature sensitivity of growth (log rate, overwrites bp if given explicitely)', default= log(self%bp))
       call self%get_parameter(self%fpday, 'fpday', '-', 'day-length factor for growth', default=1.5_rk) ! AC -07.12.2021 - Aumont et al. 2015, Eq 3a
       call self%get_parameter(self%bresp, 'bresp', 'd-1', 'basal respiration', default=0.033_rk)
       call self%get_parameter(self%pislope_s, 'pislope_s', 'g C (g Chl)-1 (W m-2)-1 d-1', 'P-I slope for small cells', default=2._rk)
@@ -321,7 +324,7 @@ contains
          ! ======================================================================================
          ! Jorn: From p4zint
          !tgfunc = EXP( 0.063913 * tem )  ! Jorn: Eq 4a in PISCES-v2 paper, NB EXP(0.063913) = 1.066 = b_P
-         tgfunc = EXP( self%logbp * tem )  ! AC 07.12.2021 - replaced hard-coded value with parameter for bp. Log(bp) considered instead of bp for perturbation purposes).
+         tgfunc = EXP( self%logbp * tem ) ! AC 07.12.2021 - replaced hard-coded value with parameter for bp. Log(bp) considered instead of bp for perturbation purposes).
          ! ======================================================================================
 
          ! ======================================================================================

--- a/src/phytoplankton.F90
+++ b/src/phytoplankton.F90
@@ -28,7 +28,6 @@ module pisces_phytoplankton
       logical :: diatom
       logical :: calcify
       real(rk) :: mumax0
-      real(rk) :: bp
       real(rk) :: logbp
       real(rk) :: fpday
       real(rk) :: bresp
@@ -87,13 +86,15 @@ contains
       class (type_par),                      pointer :: par_model
       class (type_silicate_half_saturation), pointer :: silicate_half_saturation
 
+      real(rk) :: bp
+      
       allocate(par_model)
 
       call self%get_parameter(self%diatom, 'diatom', '', 'use silicate', default=.false.)
       call self%get_parameter(self%calcify, 'calcify', '', 'calcify', default=.false.)
       call self%get_parameter(self%mumax0, 'mumax0', 'd-1', 'maximum growth rate at 0 degrees Celsius', default=0.8_rk)    ! default=0.8 in NEMO-PISCES 4 code, confirmed by Olivier Aumont 2021-04-21
-      call self%get_parameter(self%bp, 'bp', '-', 'Temperature sensitivity of growth',default=1.066_rk)
-      call self%get_parameter(self%logbp, 'logbp', '-', 'Temperature sensitivity of growth (log rate, overwrites bp if given explicitely)', default= log(self%bp))
+      call self%get_parameter(bp, 'bp', '-', 'Temperature sensitivity of growth',default=1.066_rk)
+      call self%get_parameter(self%logbp, 'logbp', '-', 'Temperature sensitivity of growth (log rate, overwrites bp if given explicitely)', default= log(bp))
       call self%get_parameter(self%fpday, 'fpday', '-', 'day-length factor for growth', default=1.5_rk) ! AC -07.12.2021 - Aumont et al. 2015, Eq 3a
       call self%get_parameter(self%bresp, 'bresp', 'd-1', 'basal respiration', default=0.033_rk)
       call self%get_parameter(self%pislope_s, 'pislope_s', 'g C (g Chl)-1 (W m-2)-1 d-1', 'P-I slope for small cells', default=2._rk)

--- a/src/zooplankton.F90
+++ b/src/zooplankton.F90
@@ -19,7 +19,7 @@ module pisces_zooplankton
       type (type_dependency_id)     :: id_tem, id_nitrfac, id_quotan, id_quotad, id_xfracal, id_wspoc, id_wsgoc
       type (type_diagnostic_variable_id) :: id_zfezoo, id_zgrazing, id_zfrac, id_pcal
 
-      real(rk) :: grazrat, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
+      real(rk) :: grazrat, logbz, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
       real(rk) :: xthreshdia, xthreshphy, xthreshzoo, xthreshpoc
       real(rk) :: xprefn, xprefz, xprefd, xprefc, xsizedia, xdismort, phlim
    contains
@@ -38,6 +38,7 @@ contains
       call self%get_parameter(self%unass, 'unass', '1', 'non-assimilated fraction', default=0.3_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%sigma, 'sigma', '1', 'excretion as dissolved organic matter', default=0.6_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%grazrat, 'grazrat', 'd-1', 'maximum grazing rate', minimum=0._rk)
+      call self%get_parameter(self%logbz, 'logbz', '-', '(log of) Temperature sensitivity of grazing rate',default=0.07608_rk) ! AC 07.12.2021 
       call self%get_parameter(self%grazflux, 'grazflux', '(m mol C L-1)-1', 'flux-feeding rate', minimum=0._rk)
       call self%get_parameter(self%xkgraz, 'xkgraz', 'mol C L-1', 'half-saturation constant for grazing', default=20.e-6_rk, minimum=0._rk)
       call self%get_parameter(self%xprefn, 'xprefn', '-', 'preference for nanophytoplankton', minimum=0._rk)
@@ -157,7 +158,8 @@ contains
          _GET_(self%id_tem, tem)
          _GET_(self%id_nitrfac, nitrfac)
 
-         tgfunc2 = EXP( 0.07608_rk  * tem )         ! Jorn: from p4zint.F90, equivalent to Eq 25b as NB EXP(0.07608) = 1.079 = b_Z
+!         tgfunc2 = EXP( 0.07608_rk  * tem )        ! Jorn: from p4zint.F90, equivalent to Eq 25b as NB EXP(0.07608) = 1.079 = b_Z
+         tgfunc2 = EXP( self%logbz  * tem )         ! AC: set log(bz) as parameter.
 
          zcompa = MAX( ( c - 1.e-9_rk ), 0.e0_rk )
          zfact   = xstep * tgfunc2 * zcompa

--- a/src/zooplankton.F90
+++ b/src/zooplankton.F90
@@ -19,7 +19,7 @@ module pisces_zooplankton
       type (type_dependency_id)     :: id_tem, id_nitrfac, id_quotan, id_quotad, id_xfracal, id_wspoc, id_wsgoc
       type (type_diagnostic_variable_id) :: id_zfezoo, id_zgrazing, id_zfrac, id_pcal
 
-      real(rk) :: grazrat, bz, logbz, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
+      real(rk) :: grazrat, logbz, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
       real(rk) :: xthreshdia, xthreshphy, xthreshzoo, xthreshpoc
       real(rk) :: xprefn, xprefz, xprefd, xprefc, xsizedia, xdismort, phlim
    contains
@@ -33,13 +33,15 @@ contains
       class (type_pisces_zooplankton), intent(inout), target :: self
       integer,                         intent(in)            :: configunit
 
+      real(rk) :: bz
+      
       call self%get_parameter(self%epsher, 'epsher', '1', 'maximum growth efficiency', minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%epshermin, 'epshermin', '1', 'minimum growth efficiency', minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%unass, 'unass', '1', 'non-assimilated fraction', default=0.3_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%sigma, 'sigma', '1', 'excretion as dissolved organic matter', default=0.6_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%grazrat, 'grazrat', 'd-1', 'maximum grazing rate', minimum=0._rk)
-      call self%get_parameter(self%bz, 'bz', '-', 'Temperature sensitivity of grazing rate',default=1.079_rk)
-      call self%get_parameter(self%logbz, 'logbz', '-', 'Temperature sensitivity of grazing rate (log rate, overwrites bz if given explicitely)', default= log(self%bz))
+      call self%get_parameter(bz, 'bz', '-', 'Temperature sensitivity of grazing rate',default=1.079_rk)
+      call self%get_parameter(self%logbz, 'logbz', '-', 'Temperature sensitivity of grazing rate (log rate, overwrites bz if given explicitely)', default= log(bz))
       call self%get_parameter(self%grazflux, 'grazflux', '(m mol C L-1)-1', 'flux-feeding rate', minimum=0._rk)
       call self%get_parameter(self%xkgraz, 'xkgraz', 'mol C L-1', 'half-saturation constant for grazing', default=20.e-6_rk, minimum=0._rk)
       call self%get_parameter(self%xprefn, 'xprefn', '-', 'preference for nanophytoplankton', minimum=0._rk)

--- a/src/zooplankton.F90
+++ b/src/zooplankton.F90
@@ -218,7 +218,7 @@ contains
          zgrazp    = zgraze  * self%xprefn * zcompaph  * zdenom2     ! Jorn: ingestion of nanophytoplankton carbon
          zgrazpoc  = zgraze  * self%xprefc * zcompapoc * zdenom2     ! Jorn: ingestion of POC
          zgrazd    = zgraze  * self%xprefd * zcompadi  * zdenom2     ! Jorn: ingestion of diatom carbon
-         zgrazz    = zgraze  * self%xprefd * zcompaz   * zdenom2     ! Jorn: ingestion of microzooplankton carbon
+         zgrazz    = zgraze  * self%xprefz * zcompaz   * zdenom2     ! Jorn: ingestion of microzooplankton carbon
 
          ! Jorn: compute specific loss rates for prey carbon, and apply those to prey iron too
          zgrazpf   = zgrazp    * nfe / (phy + rtrn)   ! Jorn: ingestion of nanophytoplankton Fe

--- a/src/zooplankton.F90
+++ b/src/zooplankton.F90
@@ -19,7 +19,7 @@ module pisces_zooplankton
       type (type_dependency_id)     :: id_tem, id_nitrfac, id_quotan, id_quotad, id_xfracal, id_wspoc, id_wsgoc
       type (type_diagnostic_variable_id) :: id_zfezoo, id_zgrazing, id_zfrac, id_pcal
 
-      real(rk) :: grazrat, logbz, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
+      real(rk) :: grazrat, bz, logbz, resrat, xkmort, mzrat, xthresh, xkgraz, ferat, epsher, epshermin, unass, sigma, part, grazflux
       real(rk) :: xthreshdia, xthreshphy, xthreshzoo, xthreshpoc
       real(rk) :: xprefn, xprefz, xprefd, xprefc, xsizedia, xdismort, phlim
    contains
@@ -38,7 +38,8 @@ contains
       call self%get_parameter(self%unass, 'unass', '1', 'non-assimilated fraction', default=0.3_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%sigma, 'sigma', '1', 'excretion as dissolved organic matter', default=0.6_rk, minimum=0._rk, maximum=1._rk)
       call self%get_parameter(self%grazrat, 'grazrat', 'd-1', 'maximum grazing rate', minimum=0._rk)
-      call self%get_parameter(self%logbz, 'logbz', '-', '(log of) Temperature sensitivity of grazing rate',default=0.07608_rk) ! AC 07.12.2021 
+      call self%get_parameter(self%bz, 'bz', '-', 'Temperature sensitivity of grazing rate',default=1.079_rk)
+      call self%get_parameter(self%logbz, 'logbz', '-', 'Temperature sensitivity of grazing rate (log rate, overwrites bz if given explicitely)', default= log(self%bz))
       call self%get_parameter(self%grazflux, 'grazflux', '(m mol C L-1)-1', 'flux-feeding rate', minimum=0._rk)
       call self%get_parameter(self%xkgraz, 'xkgraz', 'mol C L-1', 'half-saturation constant for grazing', default=20.e-6_rk, minimum=0._rk)
       call self%get_parameter(self%xprefn, 'xprefn', '-', 'preference for nanophytoplankton', minimum=0._rk)


### PR DESCRIPTION
In particular, this was done to allow perturbing the parameters considered in the stocahstic modelling works of Garnier et al, 2016 http://dx.doi.org/10.1016/j.jmarsys.2015.10.012

New paramters:

  * bp for temperature factor on phytoplankton growth. Eq 4a in PISCES-v2 paper
  * bz for temperature factor on zooplankton grazing. Eq 25b
  * fpday for daylength factor. Aumont et al. 2015, Eq 3a

! For the temperature factors on phyto growth (bp) and zoo grazing (bz), I had to use the logarithm form used by Garnier et al, 2016, instead of the b parameters directly (as in Aumont et al. 2015).
  Yet, default values provides equivalence to Aumont et al. 2015.
  The reason behind adopting the log form in the parameter directly was to ease perturbing this parameter within parsac with "usual" ranges +/-30 %.

! In addition, I modified the default value of self%pislope_l to copy the value of self%pislope_s.
  Again this is equivalent to previous setup, but ensure both parameters maintain the same value within parsac perturbation.